### PR TITLE
Use static addresses for unit tests

### DIFF
--- a/tests/csharp-quasar-base.Tests/TransactionTests.cs
+++ b/tests/csharp-quasar-base.Tests/TransactionTests.cs
@@ -17,17 +17,17 @@ namespace csharp_stellar_base.Tests
             Stellar.Network.CurrentNetwork = "";
         }
 
-        public Stellar.Transaction SampleTransaction()
+        public Stellar.Transaction SampleTransaction(string destAddress)
         {
             Stellar.Network.CurrentNetwork = "";
 
             var master = KeyPair.Master();
-            var random = KeyPair.Random();
+            var dest = string.IsNullOrEmpty(destAddress) ? KeyPair.Random() : KeyPair.FromAddress(destAddress);
 
             var sourceAccount = new Account(master, 1);
 
             CreateAccountOperation operation =
-                new CreateAccountOperation.Builder(random, 1000)
+                new CreateAccountOperation.Builder(dest, 1000)
                 //.SetSourceAccount(master)
                 .Build();
 
@@ -42,14 +42,14 @@ namespace csharp_stellar_base.Tests
         [TestMethod]
         public void SignatureBaseTest()
         {
-            var transaction = SampleTransaction();
+            var transaction = SampleTransaction("GDICFS3KJ3ZTW4COVPUX7OCOAZKLLNFAM5FIYSN5FKKM7M7QNXLBPCCH");
             var txXdr = transaction.ToXdr();
 
             var writer = new Stellar.Generated.ByteWriter();
             Stellar.Generated.Transaction.Encode(writer, txXdr);
             string sig64 = Convert.ToBase64String(writer.ToArray());
 
-            string sigSample64 = "AAAAAP7Ru1nO+h1oAv7VJP5i+LRBxajZxBQ+gOtOLhkssYBmAAAAZAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAEAAAAAAAAACQAAAAFVU0QAAAAAAP7Ru1nO+h1oAv7VJP5i+LRBxajZxBQ+gOtOLhkssYBmAAAAAQAAAAEAAAAA";
+            string sigSample64 = "AAAAAL6Qe0ushP7lzogR2y3vyb8LKiorvD1U2KIlfs1wRBliAAAAZAAAAAAAAAABAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAA0CLLak7zO3BOq+l/uE4GVLW0oGdKjEm9KpTPs/Bt1hcAAAAAAAAD6AAAAAA=";
             byte[] sigSample = Convert.FromBase64String(sigSample64);
 
             var reader = new Stellar.Generated.ByteReader(sigSample);
@@ -63,12 +63,12 @@ namespace csharp_stellar_base.Tests
         [TestMethod]
         public void HashTest()
         {
-            var transaction = SampleTransaction();
+            var transaction = SampleTransaction("GDICFS3KJ3ZTW4COVPUX7OCOAZKLLNFAM5FIYSN5FKKM7M7QNXLBPCCH");
 
             byte[] hash = transaction.Hash();
             string hash64 = Convert.ToBase64String(hash);
 
-            string hashSample64 = "8eKVr1wYJFImQO7p4Ol0qC4TI2yVYjbRnV+d+a3uGHc=";
+            string hashSample64 = "bMPzusbyC+LYcRcxTilrKuSSKTwMVE+vbFdN745w1to=";
 
             Assert.AreEqual(hashSample64, hash64);
         }


### PR DESCRIPTION
Of course I didn't calculate the correct hashes myself. I ran the test and copied the actual output as expectation.
